### PR TITLE
Update to compile with LLVM 3.7.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,13 @@ if (${LLVM_CONFIG} STREQUAL "LLVM_CONFIG-NOTFOUND")
 endif()
 message(STATUS "Using llvm-config: ${LLVM_CONFIG}")
 
-exec_program(${LLVM_CONFIG}
-	ARGS --prefix
-	OUTPUT_VARIABLE LLVM_PREFIX)
+exec_program(${LLVM_CONFIG} ARGS --prefix OUTPUT_VARIABLE LLVM_PREFIX)
+exec_program(${LLVM_CONFIG} ARGS --cxxflags OUTPUT_VARIABLE LLVM_DEFINITIONS)
+exec_program(${LLVM_CONFIG} ARGS --includedir OUTPUT_VARIABLE LLVM_INCLUDE_DIRS)
+exec_program(${LLVM_CONFIG} ARGS --libdir   OUTPUT_VARIABLE LLVM_LIBRARY_DIRS)
 
 set(CMAKE_MODULE_PATH "${LLVM_PREFIX}/share/llvm/cmake")
 
-find_package(LLVM)
 set(LLVM_RUNTIME_OUTPUT_INTDIR ".")
 set(LLVM_LIBRARY_OUTPUT_INTDIR ".")
 include(HandleLLVMOptions)

--- a/SimplePass.cc
+++ b/SimplePass.cc
@@ -5,7 +5,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstVisitor.h"
-#include "llvm/PassManager.h"
+#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 
 
@@ -107,7 +107,7 @@ char SimplePass::ID;
 /// This function is called by the PassManagerBuilder to add the pass to the
 /// pass manager.  You can query the builder for the optimisation level and so
 /// on to decide whether to insert the pass.
-void addSimplePass(const PassManagerBuilder &Builder, PassManagerBase &PM) {
+void addSimplePass(const PassManagerBuilder &Builder, legacy::PassManagerBase &PM) {
   PM.add(new SimplePass());
 }
 


### PR DESCRIPTION
Stop trying to find the FindLLVM.cmake file, as it doesn't seem to exist
any more. Instead, continue working around LLVM CMake brokenness by calling
the llvm-config binary a bit more. Also, the PassManager used here seems
to be deprecated, but it still works... for now...